### PR TITLE
check that paths are valid before expanding tar files

### DIFF
--- a/src/dockerfile-add-scanner/cli/scan.go
+++ b/src/dockerfile-add-scanner/cli/scan.go
@@ -388,13 +388,19 @@ func extractURLToPath(u *url.URL, path string, decompress decompress) error {
 			return err
 		}
 
+		if strings.Contains(header.Name, "..") {
+			return fmt.Errorf("cannot expand beyond root for %s", header.Name)
+		}
+
+		target := filepath.Join(path, header.Name)
+
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.Mkdir(filepath.Join(path, header.Name), 0755); err != nil {
+			if err := os.Mkdir(target, 0755); err != nil {
 				log.Fatalf("extract: Mkdir() failed: %s", err.Error())
 			}
 		case tar.TypeReg:
-			outFile, err := os.Create(filepath.Join(path, header.Name))
+			outFile, err := os.Create(target)
 			if err != nil {
 				log.Fatalf("extract: Create() failed: %s", err.Error())
 			}

--- a/src/github-sbom-generator/cli/generate.go
+++ b/src/github-sbom-generator/cli/generate.go
@@ -368,13 +368,19 @@ func extractURLToPath(u string, path string, decompress decompress) error {
 			return err
 		}
 
+		if strings.Contains(header.Name, "..") {
+			return fmt.Errorf("cannot expand beyond root for %s", header.Name)
+		}
+
+		target := filepath.Join(path, header.Name)
+
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.Mkdir(filepath.Join(path, header.Name), 0755); err != nil {
+			if err := os.Mkdir(target, 0755); err != nil {
 				log.Fatalf("extract: Mkdir() failed: %s", err.Error())
 			}
 		case tar.TypeReg:
-			outFile, err := os.Create(filepath.Join(path, header.Name))
+			outFile, err := os.Create(target)
 			if err != nil {
 				log.Fatalf("extract: Create() failed: %s", err.Error())
 			}


### PR DESCRIPTION
Fixes https://github.com/lf-edge/eve-build-tools/security/code-scanning/1

Fixed https://github.com/lf-edge/eve-build-tools/security/code-scanning/2