### PR TITLE
Bump builder image to golang:1.25-alpine3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Golang runtime as a parent image
-FROM golang:1.24-alpine3.20 AS builder
+FROM golang:1.25-alpine3.22 AS builder
 
 RUN apk --no-cache add make
 


### PR DESCRIPTION
Open Dependabot updates for `go-git/v5` (v5.19.0) and `go-billy/v5`
(v5.9.0) raise the modules' `go` directive to 1.25.0, which Go
enforces as a floor for any consumer. The current
`golang:1.24-alpine3.20` builder can no longer compile
`github-sbom-generator` or `dockerfile-add-scanner` once those
updates land. Move the builder stage to `golang:1.25-alpine3.22`;
the runtime stage stays on `alpine:3.20`.

Landing this first lets the four open Dependabot dependency PRs
(#65, #66, #67, #68) build, and unblocks the six open security
alerts (go-git object-parsing high; go-billy path-traversal high;
go-billy symlink-loop medium).